### PR TITLE
Use qualified imports for servant

### DIFF
--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-servant
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       Interoperability with Servant
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-webserver-servant/lib/Core/Webserver/Servant.hs
+++ b/core-webserver-servant/lib/Core/Webserver/Servant.hs
@@ -81,7 +81,8 @@ prepareRoutes ::
 prepareRoutes proxy = prepareRoutesWithContext proxy Servant.EmptyContext
 
 {- |
-Prepare routes as with 'prepareRoutes' above, but providing a __servant__ 'Context'.
+Prepare routes as with 'prepareRoutes' above, but providing a __servant__
+'Servant.Server.Context' in order to give detailed control of the setup.
 
 @since 0.1.1
 -}

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-servant
-version: 0.1.0.0
+version: 0.1.1.0
 synopsis: Interoperability with Servant
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
Almost overkill, but adding `Servant.` as the qualified import for all the **servant** types. This ok?